### PR TITLE
[postgres] make init scripts idempotent

### DIFF
--- a/src/ffspostgres/init-scripts/10-ffs_schema.sql
+++ b/src/ffspostgres/init-scripts/10-ffs_schema.sql
@@ -1,13 +1,14 @@
 -- Copyright The OpenTelemetry Authors
 -- SPDX-License-Identifier: Apache-2.0
 
-CREATE TABLE public.featureflags (
+CREATE TABLE IF NOT EXISTS public.featureflags (
     name character varying(255),
     description character varying(255),
     enabled double precision DEFAULT 0.0 NOT NULL
 );
 
+ALTER TABLE ONLY public.featureflags DROP CONSTRAINT featureflags_pkey;
 ALTER TABLE ONLY public.featureflags ADD CONSTRAINT featureflags_pkey PRIMARY KEY (name);
 
-CREATE UNIQUE INDEX featureflags_name_index ON public.featureflags USING btree (name);
+CREATE UNIQUE INDEX IF NOT EXISTS featureflags_name_index ON public.featureflags USING btree (name);
 

--- a/src/ffspostgres/init-scripts/20-ffs_data.sql
+++ b/src/ffspostgres/init-scripts/20-ffs_data.sql
@@ -13,4 +13,5 @@ VALUES
     ('paymentServiceSimulateSlownessUpperBound', 'Maximum simulated delay in milliseconds in payment service, if enabled', 600),
     ('shippingServiceSimulateSlowness', 'Simulate slow response times in the shipping service', 0),
     ('shippingServiceSimulateSlownessLowerBound', 'Minimum simulated delay in milliseconds in shipping service, if enabled', 250),
-    ('shippingServiceSimulateSlownessUpperBound', 'Maximum simulated delay in milliseconds in shipping service, if enabled', 400);
+    ('shippingServiceSimulateSlownessUpperBound', 'Maximum simulated delay in milliseconds in shipping service, if enabled', 400)
+    ON CONFLICT DO NOTHING;


### PR DESCRIPTION
This allows to attach a persistent volume to the PostgreSQL service and still always run the init scripts on startup. For the first startup with a fresh volume, the database will be initialized correctly; on subsequent starts the init scripts will do nothing.