### PR TITLE
[dash0] scripts for deploying the otel demo to k8s locally

### DIFF
--- a/.licenserc.json
+++ b/.licenserc.json
@@ -46,7 +46,7 @@
         "src/featureflagservice/priv/",
         "src/productcatalogservice/genproto/",
         "internal/tools/",
-        ".github/actions/deploy-demo/action.yaml",
-        ".github/actions/update-env-file/action.yaml"
+        ".github/actions/",
+        "kubernetes/local/"
     ]
   }

--- a/kubernetes/local/.gitignore
+++ b/kubernetes/local/.gitignore
@@ -1,0 +1,3 @@
+dash0-values.yaml
+ns1-values.yaml
+ns2-values.yaml

--- a/kubernetes/local/README.md
+++ b/kubernetes/local/README.md
@@ -1,0 +1,4 @@
+Helper Scripts to Deploy the Dash0 fork of the OpenTelemetry Demo to Kubernetes Locally
+=======================================================================================
+
+See <https://docs.google.com/document/d/1ASCn8AUR0ehqSynsUkTqvH2biTYsFAxz1rXi1Lkh3DE/edit#heading=h.sku3rt6c70ac>.

--- a/kubernetes/local/cross-namespace-service-names.yaml
+++ b/kubernetes/local/cross-namespace-service-names.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: opentelemetry-demo-in-ns2-emailservice
+  namespace: otel-demo-ns1
+spec:
+  type: ExternalName
+  externalName: opentelemetry-demo-ns2-emailservice.otel-demo-ns2.svc.cluster.local
+  ports:
+  - port: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: opentelemetry-demo-in-ns2-paymentservice
+  namespace: otel-demo-ns1
+spec:
+  type: ExternalName
+  externalName: opentelemetry-demo-ns2-paymentservice.otel-demo-ns2.svc.cluster.local
+  ports:
+  - port: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: opentelemetry-demo-in-ns2-shippingservice
+  namespace: otel-demo-ns1
+spec:
+  type: ExternalName
+  externalName: opentelemetry-demo-ns2-shippingservice.otel-demo-ns2.svc.cluster.local
+  ports:
+  - port: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: opentelemetry-demo-in-ns1-featureflagservice
+  namespace: otel-demo-ns2
+spec:
+  type: ExternalName
+  externalName: opentelemetry-demo-ns1-featureflagservice.otel-demo-ns1.svc.cluster.local
+  ports:
+  - name: grpc
+    port: 50053
+  - name: http
+    port: 8081
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: opentelemetry-demo-in-ns1-quoteservice
+  namespace: otel-demo-ns2
+spec:
+  type: ExternalName
+  externalName: opentelemetry-demo-ns1-quoteservice.otel-demo-ns1.svc.cluster.local
+  ports:
+  - port: 8080

--- a/kubernetes/local/dash0-one-ns.yq
+++ b/kubernetes/local/dash0-one-ns.yq
@@ -1,0 +1,2 @@
+.otelDemo.helm |
+.default.image.pullSecrets=[{"name": "regcred"}]

--- a/kubernetes/local/deploy-two-namespaces.sh
+++ b/kubernetes/local/deploy-two-namespaces.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd -P -- "$(dirname -- "$0")"
+
+./teardown.sh
+
+sleep 5
+
+yq --from-file ns1.yq ../../../dash0-configuration/demo/environments/aws/demo-eu-west-1-demo.yaml > ns1-values.yaml
+yq --from-file ns2.yq ../../../dash0-configuration/demo/environments/aws/demo-eu-west-1-demo.yaml > ns2-values.yaml
+
+helm install --namespace otel-demo-ns1 --create-namespace opentelemetry-demo-postgresql oci://registry-1.docker.io/bitnamicharts/postgresql --values postgres-values.yaml
+helm install --namespace otel-demo-ns1 --create-namespace opentelemetry-demo-ns1 open-telemetry/opentelemetry-demo --values ns1-values.yaml
+helm install --namespace otel-demo-ns2 --create-namespace opentelemetry-demo-ns2 open-telemetry/opentelemetry-demo --values ns2-values.yaml
+kubectl apply -f cross-namespace-service-names.yaml
+kubectl apply --namespace otel-demo-ns1 -f postgres-service-two-namespaces.yaml
+
+kubectl cp ../../src/ffspostgres/init-scripts/10-ffs_schema.sql --namespace otel-demo-ns1 opentelemetry-demo-postgresql-0:/tmp/
+kubectl cp ../../src/ffspostgres/init-scripts/20-ffs_data.sql --namespace otel-demo-ns1 opentelemetry-demo-postgresql-0:/tmp/
+kubectl exec --namespace otel-demo-ns1 opentelemetry-demo-postgresql-0 -- psql postgresql://ffs:ffs@localhost/ffs -a -f /tmp/10-ffs_schema.sql
+kubectl exec --namespace otel-demo-ns1 opentelemetry-demo-postgresql-0 -- psql postgresql://ffs:ffs@localhost/ffs -a -f /tmp/20-ffs_data.sql
+
+kubectl port-forward --namespace otel-demo-ns1 service/opentelemetry-demo-ns1-frontendproxy 8080:8080
+

--- a/kubernetes/local/deploy.sh
+++ b/kubernetes/local/deploy.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd -P -- "$(dirname -- "$0")"
+
+./teardown.sh
+
+sleep 5
+
+yq --from-file dash0-one-ns.yq ../../../dash0-configuration/demo/environments/aws/demo-eu-west-1-demo.yaml > dash0-values.yaml
+
+helm install --namespace otel-demo-ns --create-namespace opentelemetry-demo-postgresql oci://registry-1.docker.io/bitnamicharts/postgresql --values postgres-values.yaml
+helm install \
+  --namespace otel-demo-ns \
+  --create-namespace \
+  opentelemetry-demo \
+  open-telemetry/opentelemetry-demo  \
+  --values dash0-values.yaml
+kubectl apply --namespace otel-demo-ns -f postgres-service.yaml
+
+kubectl cp ../../src/ffspostgres/init-scripts/10-ffs_schema.sql --namespace otel-demo-ns opentelemetry-demo-postgresql-0:/tmp/
+kubectl cp ../../src/ffspostgres/init-scripts/20-ffs_data.sql --namespace otel-demo-ns opentelemetry-demo-postgresql-0:/tmp/
+kubectl exec --namespace otel-demo-ns opentelemetry-demo-postgresql-0 -- psql postgresql://ffs:ffs@localhost/ffs -a -f /tmp/10-ffs_schema.sql
+kubectl exec --namespace otel-demo-ns opentelemetry-demo-postgresql-0 -- psql postgresql://ffs:ffs@localhost/ffs -a -f /tmp/20-ffs_data.sql
+
+kubectl port-forward --namespace otel-demo-ns service/opentelemetry-demo-frontendproxy 8080:8080
+

--- a/kubernetes/local/ns1.yq
+++ b/kubernetes/local/ns1.yq
@@ -1,0 +1,29 @@
+.otelDemo.helm |
+.default.image.pullSecrets=[{"name": "regcred"}] |
+del(.default.envOverrides) |
+.components.ffsPostgres.enabled=false |
+.components.accountingService.enabled=true |
+.components.adService.enabled=true |
+.components.cartService.enabled=true |
+.components.checkoutService.enabled=true |
+.components.currencyService.enabled=true |
+.components.emailService.enabled=true |
+.components.cartService.enabled=true |
+.components.checkoutService.enabled=true |
+.components.checkoutService.envOverrides=[
+{ "name": "FEATURE_FLAG_GRPC_SERVICE_ADDR", "value": "opentelemetry-demo-featureflagservice:50053" }, { "name": "EMAIL_SERVICE_ADDR", "value": "http://opentelemetry-demo-in-ns2-emailservice:8080" }, { "name": "PAYMENT_SERVICE_ADDR", "value": "opentelemetry-demo-in-ns2-paymentservice:8080" }, {"name": "SHIPPING_SERVICE_ADDR", "value": "opentelemetry-demo-in-ns2-shippingservice:8080" } ] |
+.components.currencyService.enabled=true |
+.components.emailService.enabled=false |
+.components.featureflagService.enabled=true |
+.components.frauddetectionService.enabled=true |
+.components.frontend.enabled=true |
+.components.frontend.envOverrides=[{ "name": "SHIPPING_SERVICE_ADDR", "value": "opentelemetry-demo-in-ns2-shippingservice:8080" } ] |
+.components.frontendProxy.enabled=true |
+.components.kafka.enabled=true |
+.components.loadgenerator.enabled=true |
+.components.paymentService.enabled=false |
+.components.productCatalogService.enabled=true |
+.components.quoteService.enabled=true |
+.components.recommendationService.enabled=true |
+.components.redis.enabled=true |
+.components.shippingService.enabled=false

--- a/kubernetes/local/ns2.yq
+++ b/kubernetes/local/ns2.yq
@@ -1,0 +1,34 @@
+.otelDemo.helm |
+del(.prometheus) |
+.default.image.pullSecrets=[{"name": "regcred"}] |
+del(.default.envOverrides) |
+.components.ffsPostgres.enabled=false |
+.components.accountingService.enabled=false |
+.components.adService.enabled=false |
+.components.cartService.enabled=false |
+.components.checkoutService.enabled=false |
+.components.currencyService.enabled=false |
+.components.emailService.enabled=false |
+.components.cartService.enabled=false |
+.components.checkoutService.enabled=false |
+.components.currencyService.enabled=false |
+.components.emailService.enabled=true |
+.components.featureflagService.enabled=false |
+.components.frauddetectionService.enabled=false |
+.components.frontend.enabled=false |
+.components.frontendProxy.enabled=false |
+.components.kafka.enabled=false |
+.components.loadgenerator.enabled=false |
+.components.paymentService.enabled=true |
+.components.paymentService.envOverrides=[{ "name": "FEATURE_FLAG_GRPC_SERVICE_ADDR", "value": "opentelemetry-demo-in-ns1-featureflagservice:50053" } ] |
+.components.productCatalogService.enabled=false |
+.components.quoteService.enabled=false |
+.components.recommendationService.enabled=false |
+.components.redis.enabled=false |
+.components.shippingService.enabled=true |
+.components.shippingService.envOverrides=[{ "name": "FEATURE_FLAG_GRPC_SERVICE_ADDR", "value": "opentelemetry-demo-in-ns1-featureflagservice:50053" }, { "name": "QUOTE_SERVICE_ADDR", "value": "http://opentelemetry-demo-in-ns1-quoteservice:8080" }] |
+del(.grafana) |
+.jaeger.enabled=false |
+.prometheus.enabled=false |
+.grafana.enabled=false
+

--- a/kubernetes/local/postgres-service-two-namespaces.yaml
+++ b/kubernetes/local/postgres-service-two-namespaces.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: opentelemetry-demo-ns1-ffspostgres
+spec:
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      protocol: TCP
+      targetPort: tcp-postgresql
+  selector:
+    app.kubernetes.io/component: primary
+    app.kubernetes.io/instance: opentelemetry-demo-postgresql
+    app.kubernetes.io/name: postgresql
+  type: ClusterIP

--- a/kubernetes/local/postgres-service.yaml
+++ b/kubernetes/local/postgres-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: opentelemetry-demo-ffspostgres
+spec:
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      protocol: TCP
+      targetPort: tcp-postgresql
+  selector:
+    app.kubernetes.io/component: primary
+    app.kubernetes.io/instance: opentelemetry-demo-postgresql
+    app.kubernetes.io/name: postgresql
+  type: ClusterIP

--- a/kubernetes/local/postgres-values.yaml
+++ b/kubernetes/local/postgres-values.yaml
@@ -1,0 +1,6 @@
+global:
+  postgresql:
+    auth:
+      username: "ffs"
+      password: "ffs"
+      database: "ffs"

--- a/kubernetes/local/teardown.sh
+++ b/kubernetes/local/teardown.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd -P -- "$(dirname -- "$0")"
+
+pwd
+
+# tear down things installed by deploy.sh
+helm uninstall --namespace otel-demo-ns --ignore-not-found opentelemetry-demo-postgresql
+helm uninstall --namespace otel-demo-ns --ignore-not-found opentelemetry-demo
+kubectl delete --namespace otel-demo-ns --ignore-not-found -f postgres-service.yaml
+kubectl delete --namespace otel-demo-ns --ignore-not-found -f postgres-service-two-namespaces.yaml
+
+# tear down things installed by deploy-two-namespaces.sh
+helm uninstall --namespace otel-demo-ns1 --ignore-not-found opentelemetry-demo-ns1
+helm uninstall --namespace otel-demo-ns2 --ignore-not-found opentelemetry-demo-ns2
+helm uninstall --namespace otel-demo-ns1 --ignore-not-found opentelemetry-demo-postgresql
+kubectl delete --namespace otel-demo-ns1 --ignore-not-found -f postgres-service.yaml
+kubectl delete --ignore-not-found -f cross-namespace-service-names.yaml
+


### PR DESCRIPTION
Either deploy to one namespace or to two different namespaces (just to make the deployment topology a bit more "interesting").

- [x] deploy to two namespaces locally, make sure services can still talk correctly to one another
- [ ] convert the local deployment back into an Argo CD deployment
