### PR TITLE
[adservice] fix error rate in ad service

### DIFF
--- a/src/adservice/src/main/java/oteldemo/AdService.java
+++ b/src/adservice/src/main/java/oteldemo/AdService.java
@@ -202,11 +202,6 @@ public final class AdService {
         return false;
       }
 
-      // Flip a coin and fail 1/10th of the time if feature flag is enabled
-      if (random.nextInt(10) != 1) {
-        return false;
-      }
-
       EvaluateProbabilityFeatureFlagResponse response =
           featureFlagServiceStub.evaluateProbabilityFeatureFlag(
               EvaluateProbabilityFeatureFlagRequest.newBuilder()


### PR DESCRIPTION
When introducing error rates/probabilities with 430b4c9, the correct move would have been to remove the 1/10 hard coded error probability in adservice (similar to b55b147 for cart service), since asking the feature flag service whether adServiceFailure is enabled is a random experiment each time anyway. Leaving the 1/10 probability in place in ad service as well skews the error rate by a factor of 1/10.