### PR TITLE
Improve logging to demo Triage and Log grouping

### DIFF
--- a/src/productcatalogservice/main.go
+++ b/src/productcatalogservice/main.go
@@ -290,6 +290,7 @@ func (p *productCatalog) GetProduct(ctx context.Context, req *pb.GetProductReque
 		msg := fmt.Sprintf("Product Id Lookup Failed: %s", req.Id)
 		err := fmt.Errorf("ProductCatalogService Fail Feature Flag Enabled")
 		span.SetStatus(otelcodes.Error, msg)
+		span.AddEvent(msg)
 		log.WithContext(ctx).WithError(err).Errorln(msg)
 		return nil, status.Errorf(codes.Internal, msg)
 	}

--- a/src/productcatalogservice/main.go
+++ b/src/productcatalogservice/main.go
@@ -287,10 +287,10 @@ func (p *productCatalog) GetProduct(ctx context.Context, req *pb.GetProductReque
 
 	// GetProduct will fail on a specific product when feature flag is enabled
 	if p.checkProductFailure(ctx, req.Id) {
-		msg := fmt.Sprintf("Error: ProductCatalogService Fail Feature Flag Enabled")
+		msg := fmt.Sprintf("Product Id Lookup Failed: %s", req.Id)
+		err := fmt.Errorf("ProductCatalogService Fail Feature Flag Enabled")
 		span.SetStatus(otelcodes.Error, msg)
-		span.AddEvent(msg)
-		log.WithContext(ctx).WithField("request.id", req.Id).Println("ProductCatalogService Fail Feature Flag Enabled")
+		log.WithContext(ctx).WithError(err).Errorln(msg)
 		return nil, status.Errorf(codes.Internal, msg)
 	}
 
@@ -303,10 +303,10 @@ func (p *productCatalog) GetProduct(ctx context.Context, req *pb.GetProductReque
 	}
 
 	if found == nil {
-		msg := fmt.Sprintf("Product Not Found: %s", req.Id)
+		msg := fmt.Sprintf("Product Id Not Found: %s", req.Id)
 		span.SetStatus(otelcodes.Error, msg)
 		span.AddEvent(msg)
-		log.WithContext(ctx).WithField("request.id", req.Id).Error("Product Not Found")
+		log.WithContext(ctx).Error("Product Not Found")
 		return nil, status.Errorf(codes.NotFound, msg)
 	}
 
@@ -315,7 +315,7 @@ func (p *productCatalog) GetProduct(ctx context.Context, req *pb.GetProductReque
 	span.SetAttributes(
 		attribute.String("app.product.name", found.Name),
 	)
-	log.WithContext(ctx).WithField("app.product.name", found.Name).Println(msg)
+	log.WithContext(ctx).Println(msg)
 	return found, nil
 }
 

--- a/src/productcatalogservice/main.go
+++ b/src/productcatalogservice/main.go
@@ -306,7 +306,7 @@ func (p *productCatalog) GetProduct(ctx context.Context, req *pb.GetProductReque
 		msg := fmt.Sprintf("Product Not Found: %s", req.Id)
 		span.SetStatus(otelcodes.Error, msg)
 		span.AddEvent(msg)
-		log.WithContext(ctx).WithField("request.id", req.Id).Println("Product Not Found")
+		log.WithContext(ctx).WithField("request.id", req.Id).Error("Product Not Found")
 		return nil, status.Errorf(codes.NotFound, msg)
 	}
 


### PR DESCRIPTION
1. Remove explicit attributes from log records (we want Log Grouping to extract them)
2. Mark severity as Errors for logs about product not found (LogAI does not override the severity_number set by the log bridge)
3. Remove error event, we have logs now instead
4. Add stacktrace to error log