### PR TITLE
ci: migrate ECR push auth to GitHub OIDC (PLA-1294)

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -143,16 +143,22 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # OIDC-based ECR auth (PLA-1294): only runs when pushing to ECR.
+      # The github-ci-cd-ecr role only trusts refs/heads/main and refs/tags/*,
+      # which is exactly when inputs.push is true (release / nightly). PR and
+      # feature-branch builds (push=false) skip ECR auth entirely, since they
+      # never push and their refs are not trusted by the role.
       - name: Configure AWS credentials
+        if: ${{ inputs.push }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{secrets.DEPLOYMENT_WRITE_ECR_ACCESS_KEY}}
-          aws-secret-access-key: ${{secrets.DEPLOYMENT_WRITE_ECR_SECRET_ACCESS_KEY}}
+          role-to-assume: arn:aws:iam::718306648796:role/github-ci-cd-ecr
           aws-region: us-west-2
           mask-aws-account-id: true
 
       - name: Login to Amazon ECR
         id: login-ecr
+        if: ${{ inputs.push }}
         uses: aws-actions/amazon-ecr-login@v2
         with:
           mask-password: true


### PR DESCRIPTION
## Summary

Migrates ECR image-push authentication in `build-images.yml` from a long-lived AWS access key (`DEPLOYMENT_WRITE_ECR_ACCESS_KEY` / `DEPLOYMENT_WRITE_ECR_SECRET_ACCESS_KEY`) to **GitHub OIDC**, assuming the IAM role `arn:aws:iam::718306648796:role/github-ci-cd-ecr`. Part of Linear **PLA-1294**.

## Changes

- `Configure AWS credentials` now uses `role-to-assume: arn:aws:iam::718306648796:role/github-ci-cd-ecr` instead of static access-key secrets (region `us-west-2`, `mask-aws-account-id: true` unchanged).
- Both `Configure AWS credentials` and `Login to Amazon ECR` are gated behind `if: ${{ inputs.push }}`.
- GCP auth/login, the matrix build step, and everything else are unchanged. The build step already carries `push: ${{ inputs.push }}` so it never pushes on `push=false` invocations, and the ECR tag targets use the hardcoded `env.AWS_ECR_REPO` (not `login-ecr` outputs), so skipping ECR login on `push=false` is safe.

## Why gate the ECR steps

The `github-ci-cd-ecr` role's trust policy only covers `refs/heads/main` and `refs/tags/*`. With OIDC, the credential step would **fail** on any other ref (PR `pull_request` subs, feature-branch pushes). ECR auth is only actually needed when images are pushed to ECR, i.e. `inputs.push == true`, which only happens from `release.yml` (bare semver tags) and `nightly-release.yml` (main) - both trusted refs. So gating on `inputs.push` aligns ECR auth exactly with the refs the role trusts.

> **Note:** PR and feature-branch builds (`push=false`) now skip ECR auth entirely. This is the intended behavior - those builds never push to ECR.

## ⚠️ IMPORTANT - deploy ordering

This depends on **`dash0hq/dash0-infrastructure` PR #1295** (creates the `github-ci-cd-ecr` role, trusting opentelemetry-demo `refs/heads/main` + `refs/tags/*` for the bare semver release tags) being **applied via Atlantis FIRST**. Merging this PR before the role exists will break `push=true` release / nightly runs.